### PR TITLE
Update docfx.json

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -599,7 +599,7 @@
         "docs-ref-autogen/azure-iot-*/**": "iot-hub",
         "docs-ref-autogen/azure-iot-hub/**": "iot-hub",
         "docs-ref-autogen/azure-iothub/**": "iot-hub",
-        "docs-ref-autogen/azure-iot-device/**": "iot-suite",
+        "docs-ref-autogen/azure-iot-device/**": "iot-hub",
         "docs-ref-autogen/azure-iot-provisioning-*/**": "iot-dps",
         "docs-ref-autogen/azure-monitor/**": "azure-monitor",
         "docs-ref-autogen/azure-monitoring/**": "azure-monitor",


### PR DESCRIPTION
Changing product tagging on "azure-iot-device" package from "iot-suite" to "iot-hub".    This change was approved by dev team SWE mgr and Azure SDK scripting PM contact.